### PR TITLE
Sigla LGPL depreciada, foi coletado a nova sigla para uso.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "keywords": ["PHP","Excel","OpenXML","xlsx","xls","spreadsheet"],
     "homepage": "http://phpexcel.codeplex.com",
     "type": "library",
-    "license": "LGPL",
+    "license": "LGPL-2.0-only",
     "authors": [
         {
             "name": "Maarten Balliauw",


### PR DESCRIPTION
Sigla LGPL depreciada, foi coletado a nova sigla para uso. 